### PR TITLE
Use latest craffft version instead of next/beta versions

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -142,7 +142,7 @@ vagrant up
 
 echo "- installiere WordPress und Abhängigkeiten"
 
-vagrant ssh -c 'cd /vagrant && npm set progress=false && npm install craffft@next --save-dev && make install'
+vagrant ssh -c 'cd /vagrant && npm set progress=false && npm install craffft --save-dev && make install'
 
 echo "- konfiguriere WordPress"
 


### PR DESCRIPTION
It's always possible that `@next` is behind the current "stable" version.